### PR TITLE
Update Xcelerator cohort: contact emails, Headroom & RELAI updates

### DIFF
--- a/scripts/build_xcelerator_cohort_html.py
+++ b/scripts/build_xcelerator_cohort_html.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-JSON_PATH = Path(__file__).resolve().parents[2] / "Berkeley-RDI-Xcelerator-Cohort-Mockup" / "data" / "cohort.json"
+DEFAULT_JSON = Path(__file__).resolve().parents[2] / "Berkeley-RDI-Xcelerator-Cohort-Mockup" / "data" / "cohort.json"
 IMG_PREFIX = "/assets/images/xcelerator-cohort-2026/"
 
 
@@ -104,6 +104,7 @@ def company_back(c: dict) -> str:
     founded = html.escape(f"Founded {yf}") if yf is not None else ""
 
     ws = (c.get("website") or "").strip()
+    email = (c.get("email") or "").strip()
     li_co = (c.get("linkedin") or "").strip()
     links = []
     if ws:
@@ -111,6 +112,11 @@ def company_back(c: dict) -> str:
         ws_esc = html.escape(ws, quote=True)
         links.append(
             f'<a href="{ws_esc}" target="_blank" rel="noopener" class="a16z-link">{label} ↗</a>'
+        )
+    if email:
+        email_esc = html.escape(email, quote=True)
+        links.append(
+            f'<a href="mailto:{email_esc}" class="a16z-link">{email_esc} ✉</a>'
         )
     if li_co:
         li_esc = html.escape(li_co, quote=True)
@@ -136,7 +142,8 @@ def company_back(c: dict) -> str:
 
 
 def main() -> None:
-    data = json.loads(JSON_PATH.read_text(encoding="utf-8"))
+    json_path = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_JSON
+    data = json.loads(json_path.read_text(encoding="utf-8"))
     cohort_name = html.escape(data.get("cohort_name", "2026 Spring Cohort"))
     # Match mockup app/main.py: only featured companies (others still being collected)
     companies = [c for c in data["companies"] if c.get("featured")]

--- a/xcelerator.html
+++ b/xcelerator.html
@@ -277,6 +277,7 @@
             </div>
         </section>
 
+
         <section class="content-section">
             <div class="container">
                 <h2 class="section-title">2026 Spring Cohort</h2>
@@ -365,6 +366,7 @@
             </div>
             <div class="a16z-links">
               <a href="https://www.cognee.ai" target="_blank" rel="noopener" class="a16z-link">www.cognee.ai ↗</a>
+              <a href="mailto:social@cognee.ai" class="a16z-link">social@cognee.ai ✉</a>
               <a href="https://www.linkedin.com/company/103889898" target="_blank" rel="noopener" class="a16z-link">LinkedIn ↗</a>
             </div>
           </div>
@@ -407,6 +409,7 @@
             </div>
             <div class="a16z-links">
               <a href="https://www.nimblemind.ai/" target="_blank" rel="noopener" class="a16z-link">www.nimblemind.ai ↗</a>
+              <a href="mailto:contact@nimblemind.ai" class="a16z-link">contact@nimblemind.ai ✉</a>
               <a href="https://www.linkedin.com/company/nimblemindai" target="_blank" rel="noopener" class="a16z-link">LinkedIn ↗</a>
             </div>
           </div>
@@ -422,7 +425,7 @@
           </div>
           <div class="a16z-card-back">
             <h4>Headroom</h4>
-            <p class="a16z-desc">Headroom is the context optimization layer for LLM agents, cutting tokens 40-90% losslessly across text, voice, and regulated verticals. The open-source proxy (1,300+ GitHub stars, 40K+ PyPI downloads, 50B tokens saved) integrates with LangChain, Claude Code, Codex, and MCP.</p>
+            <p class="a16z-desc">Headroom is the context optimization layer for LLM agents, cutting tokens 40-90% losslessly across text, voice, and regulated verticals. The open-source proxy (1,700+ GitHub stars, 40K+ PyPI downloads, 200B+ tokens saved) integrates with LangChain, Claude Code, Codex, and MCP.</p>
             <div class="a16z-founders">
                 <div class="a16z-founder">
                   <img class="a16z-founder-headshot" src="/assets/images/xcelerator-cohort-2026/founders/tejas-chopra.jpg" alt="Tejas Chopra">
@@ -436,10 +439,11 @@
             </div>
             <div class="a16z-meta">
               <span>Fremont, CA</span>
-              <span>Founded 2024</span>
+              <span>Founded 2026</span>
             </div>
             <div class="a16z-links">
               <a href="https://headroomlabs.ai" target="_blank" rel="noopener" class="a16z-link">headroomlabs.ai ↗</a>
+              <a href="mailto:hello@headroomlabs.ai" class="a16z-link">hello@headroomlabs.ai ✉</a>
             </div>
           </div>
         </div>
@@ -449,7 +453,7 @@
           <div class="a16z-card-front">
             <div class="a16z-logo a16z-logo-img"><img src="/assets/images/xcelerator-cohort-2026/companies/relai/logo-full-clean.png" alt="RELAI"></div>
               <h3>RELAI</h3>
-            <p class="a16z-tagline">Lifelong optimization engine for AI agents that turns production failures into replayable test environments.</p>
+            <p class="a16z-tagline">The learning engine for self-improving AI agents.</p>
             <p class="a16z-hover-hint">Hover for founders →</p>
           </div>
           <div class="a16z-card-back">
@@ -499,6 +503,7 @@
             </div>
             <div class="a16z-links">
               <a href="https://relai.ai/" target="_blank" rel="noopener" class="a16z-link">relai.ai ↗</a>
+              <a href="mailto:contact@relai.ai" class="a16z-link">contact@relai.ai ✉</a>
               <a href="https://www.linkedin.com/company/relai-ai/" target="_blank" rel="noopener" class="a16z-link">LinkedIn ↗</a>
             </div>
           </div>
@@ -574,6 +579,7 @@
             </div>
             <div class="a16z-links">
               <a href="https://founding.dev" target="_blank" rel="noopener" class="a16z-link">founding.dev ↗</a>
+              <a href="mailto:talha@founding.dev" class="a16z-link">talha@founding.dev ✉</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Updates the 2026 Spring Cohort section with changes requested by cohort companies:

- Headroom: Founded year corrected from 2024 to 2026
- Headroom: Updated description with latest metrics (1,700+ GitHub stars, 200B+ tokens saved)
- RELAI: Tagline updated to "The learning engine for self-improving AI agents."
- Added contact email links for 5 companies: cognee, Nimblemind, Headroom, RELAI, Founding Dev
- Build script updated to support email fields for future rebuilds

2 files changed. No changes to CSS, images, or any other sections of the page.