### PR TITLE
Add side-event submission section under sponsorship CTA

### DIFF
--- a/events/agentic-ai-summit-2026.html
+++ b/events/agentic-ai-summit-2026.html
@@ -203,6 +203,21 @@
         </div>
       </div>
 
+      <div style="margin: 30px 0; padding: 20px; background-color: #f8f9fa; border-left: 4px solid #CB9445; border-radius: 4px;">
+        <h3 style="color: #CB9445; font-weight: 700; font-size: 20px; margin-bottom: 15px; margin-top: 0;">Hosting a Side Event?</h3>
+        <p style="font-size: 1rem; margin-bottom: 12px;">
+          Planning a meetup, workshop, dinner, or hackathon around the Summit? Submit your event to be considered for listing on the Summit website.
+        </p>
+        <p style="font-size: 0.85rem; color: #666; margin-bottom: 20px;">
+          Side events are independently organized and not officially hosted by Berkeley RDI or RDI Foundation. Submission does not guarantee inclusion.
+        </p>
+        <div style="text-align: center;">
+          <button class="styled-button" onclick="location.href='https://docs.google.com/forms/d/e/1FAIpQLSfkh3gu3p4L8abzHqFhAavPDpwuucmq1TXDW89_uVBws24fag/viewform'">
+            Submit Your Event
+          </button>
+        </div>
+      </div>
+
       <div>
         <hr style="margin-left: -20%; margin-right: -20%">
         <br>


### PR DESCRIPTION
Adds a 'Hosting a Side Event?' block beneath the Sponsorship Opportunities box on the Agentic AI Summit 2026 page, linking to the Side Event Submission Google Form. Matches existing page styling (styled-button, gold accent box). 