### PR TITLE
Agentic AI Summit 2026: update Krishnakumar Sharma title and company to CEO, Omokai

### DIFF
--- a/events/agentic-ai-summit-2026.html
+++ b/events/agentic-ai-summit-2026.html
@@ -1253,7 +1253,7 @@
                   <div class="speaker">
                       <div class="speaker-header">
                           <div class="speaker-name">Krishnakumar Sharma</div>
-                          <div class="speaker-title">Senior Director of Engineering, Delivery Hero</div>
+                          <div class="speaker-title">CEO, Omokai</div>
                       </div>
                   </div>
               </div>
@@ -2966,14 +2966,14 @@
             <p class="rdi-spk-org">Microsoft</p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
-          <div class="rdi-spk-card" data-name="krishnakumar sharma" data-org="delivery hero" data-stage="nexus">
+          <div class="rdi-spk-card" data-name="krishnakumar sharma" data-org="omokai" data-stage="nexus">
             <a href="https://www.linkedin.com/in/krisberlin/" target="_blank" rel="noopener" class="rdi-spk-link-wrap">
             <div class="rdi-spk-avatar">
               <img src="../assets/images/agentic-summit-2026/speakers/krishnakumar_sharma.png" alt="Krishnakumar Sharma" loading="lazy" />
             </div>
             <p class="rdi-spk-name">Krishnakumar Sharma</p>
-            <p class="rdi-spk-title">Senior Director of Engineering</p>
-            <p class="rdi-spk-org">Delivery Hero</p>
+            <p class="rdi-spk-title">CEO</p>
+            <p class="rdi-spk-org">Omokai</p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="shaghayegh gharghabi" data-org="nvidia" data-stage="nexus">


### PR DESCRIPTION
Updates Krishnakumar Sharma's title and company to CEO, Omokai, per his request. The previous information (Senior Director of Engineering, Delivery Hero) was outdated. Changed in both the agenda entry and his speaker card so the two stay consistent.

Verification: div balance unchanged from base, old title and company removed everywhere, agenda and card both updated and consistent.