### PR TITLE
Fix title/org display for speakers with two affiliations

### DIFF
--- a/events/agentic-ai-summit-2026.html
+++ b/events/agentic-ai-summit-2026.html
@@ -285,7 +285,7 @@
                   <div class="speaker">
                       <div class="speaker-header">
                           <div class="speaker-name">Dawn Song</div>
-                          <div class="speaker-title">Professor; Co-Director, UC Berkeley; Berkeley RDI</div>
+                          <div class="speaker-title">Professor, UC Berkeley; Co-Director, Berkeley RDI</div>
                       </div>
                   </div>
               </div>
@@ -649,7 +649,7 @@
                   <div class="speaker">
                       <div class="speaker-header">
                           <div class="speaker-name">Andy Konwinski</div>
-                          <div class="speaker-title">Co-Founder, Databricks, Perplexity and Laude Ventures</div>
+                          <div class="speaker-title">Co-Founder, Databricks; Perplexity; Laude Ventures</div>
                       </div>
                   </div>
               </div>
@@ -873,7 +873,7 @@
                   <div class="speaker">
                       <div class="speaker-header">
                           <div class="speaker-name">Peter Stone</div>
-                          <div class="speaker-title">Chief Scientist; Professor, Sony AI; UT Austin</div>
+                          <div class="speaker-title">Chief Scientist, Sony AI; Professor, UT Austin</div>
                       </div>
                   </div>
                   <div class="speaker">
@@ -897,7 +897,7 @@
                   <div class="speaker">
                       <div class="speaker-header">
                           <div class="speaker-name">Bolei Zhou</div>
-                          <div class="speaker-title">Associate Professor / Chief AI Scientist, UCLA / Coco Robotics</div>
+                          <div class="speaker-title">Associate Professor, UCLA; Chief AI Scientist, Coco Robotics</div>
                       </div>
                   </div>
               </div>
@@ -1045,7 +1045,7 @@
                   <div class="speaker">
                       <div class="speaker-header">
                           <div class="speaker-name">Dan Klein</div>
-                          <div class="speaker-title">Professor / Co-founder CTO, UC Berkeley / Scaled Cognition</div>
+                          <div class="speaker-title">Professor, UC Berkeley; Co-founder CTO, Scaled Cognition</div>
                       </div>
                   </div>
               </div>
@@ -1117,7 +1117,7 @@
                   <div class="speaker">
                       <div class="speaker-header">
                           <div class="speaker-name">Sergei Gukov</div>
-                          <div class="speaker-title">Executive Director, American Institute of Mathematics / John D. MacArthur Professor of Theoretical Physics and Mathematics, California Institute of Technology</div>
+                          <div class="speaker-title">Executive Director, American Institute of Mathematics; John D. MacArthur Professor of Theoretical Physics and Mathematics, California Institute of Technology</div>
                       </div>
                   </div>
                   <div class="speaker">
@@ -1169,7 +1169,7 @@
                   <div class="speaker">
                       <div class="speaker-header">
                           <div class="speaker-name">Markus J. Buehler</div>
-                          <div class="speaker-title">Professor, Founder, CTO, MIT/Unreasonable Labs</div>
+                          <div class="speaker-title">Professor, MIT; Founder & CTO, Unreasonable Labs</div>
                       </div>
                   </div>
                   <div class="speaker">
@@ -1319,7 +1319,7 @@
                   <div class="speaker">
                       <div class="speaker-header">
                           <div class="speaker-name">Bo Li</div>
-                          <div class="speaker-title">Co-Founder and CEO, Virtue AI / UIUC</div>
+                          <div class="speaker-title">Co-Founder and CEO, Virtue AI; UIUC</div>
                       </div>
                   </div>
                   <div class="speaker">
@@ -1377,7 +1377,7 @@
                   <div class="speaker">
                       <div class="speaker-header">
                           <div class="speaker-name">Ion Stoica</div>
-                          <div class="speaker-title">Co-Founder; Professor, Databricks and Anyscale; UC Berkeley</div>
+                          <div class="speaker-title">Co-Founder, Databricks and Anyscale; Professor, UC Berkeley</div>
                       </div>
                   </div>
                   <div class="speaker">
@@ -1509,7 +1509,7 @@
                   <div class="speaker">
                       <div class="speaker-header">
                           <div class="speaker-name">Yu Su</div>
-                          <div class="speaker-title">CEO / Associate Professor, NeoCognition / OSU</div>
+                          <div class="speaker-title">CEO, NeoCognition; Associate Professor, OSU</div>
                       </div>
                   </div>
                   <div class="speaker">
@@ -1567,7 +1567,7 @@
                   <div class="speaker">
                       <div class="speaker-header">
                           <div class="speaker-name">Lovedeep Gondara</div>
-                          <div class="speaker-title">Head of AI R&amp;D | Adjunct Professor, Vanguard | University of British Columbia</div>
+                          <div class="speaker-title">Head of AI R&amp;D, Vanguard; Adjunct Professor, University of British Columbia</div>
                       </div>
                   </div>
                   <div class="speaker">
@@ -1591,7 +1591,7 @@
                   <div class="speaker">
                       <div class="speaker-header">
                           <div class="speaker-name">Jordan Jindong Gu</div>
-                          <div class="speaker-title">Senior Research Scientist, Google &amp; University of Oxford</div>
+                          <div class="speaker-title">Senior Research Scientist, Google; University of Oxford</div>
                       </div>
                   </div>
                   <div class="speaker">
@@ -1759,7 +1759,7 @@
                   <div class="speaker">
                       <div class="speaker-header">
                           <div class="speaker-name">Chenguang Wang</div>
-                          <div class="speaker-title">Assistant Professor / Research Advisor, University of California, Santa Cruz / Scale AI</div>
+                          <div class="speaker-title">Assistant Professor, University of California, Santa Cruz; Research Advisor, Scale AI</div>
                       </div>
                   </div>
                   <div class="speaker">
@@ -2147,14 +2147,14 @@
             <p class="rdi-spk-org">Sequoia Capital</p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
-          <div class="rdi-spk-card" data-name="andy konwinski" data-org="databricks, perplexity and laude ventures" data-stage="mainstage">
+          <div class="rdi-spk-card" data-name="andy konwinski" data-org="databricks; perplexity; laude ventures" data-stage="mainstage">
             <a href="https://andykonwinski.com/about/" target="_blank" rel="noopener" class="rdi-spk-link-wrap">
             <div class="rdi-spk-avatar">
               <img src="../assets/images/agentic-summit-2026/speakers/andy_konwinski.png" alt="Andy Konwinski" loading="lazy" />
             </div>
             <p class="rdi-spk-name">Andy Konwinski</p>
             <p class="rdi-spk-title">Co-Founder</p>
-            <p class="rdi-spk-org">Databricks, Perplexity and Laude Ventures</p>
+            <p class="rdi-spk-org">Databricks; Perplexity; Laude Ventures</p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="anjney midha" data-org="a16z" data-stage="mainstage">
@@ -2566,14 +2566,14 @@
             <p class="rdi-spk-org">LLMArena</p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
-          <div class="rdi-spk-card" data-name="sergei gukov" data-org="california institute of technology" data-stage="atlas">
+          <div class="rdi-spk-card" data-name="sergei gukov" data-org="american institute of mathematics; california institute of technology" data-stage="atlas">
             <a href="https://www.pma.caltech.edu/people/gukov" target="_blank" rel="noopener" class="rdi-spk-link-wrap">
             <div class="rdi-spk-avatar">
               <img src="../assets/images/agentic-summit-2026/speakers/sergei_gukov.png" alt="Sergei Gukov" loading="lazy" />
             </div>
             <p class="rdi-spk-name">Sergei Gukov</p>
-            <p class="rdi-spk-title">Executive Director, American Institute of Mathematics / John D. MacArthur Professor of Theoretical Physics and Mathematics</p>
-            <p class="rdi-spk-org">California Institute of Technology</p>
+            <p class="rdi-spk-title">Executive Director; John D. MacArthur Professor of Theoretical Physics and Mathematics</p>
+            <p class="rdi-spk-org">American Institute of Mathematics; California Institute of Technology</p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="tudor achim" data-org="harmonic" data-stage="atlas">
@@ -2626,14 +2626,14 @@
             <p class="rdi-spk-org">University of California, San Diego</p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
-          <div class="rdi-spk-card" data-name="bolei zhou" data-org="ucla / coco robotics" data-stage="atlas">
+          <div class="rdi-spk-card" data-name="bolei zhou" data-org="ucla; coco robotics" data-stage="atlas">
             <a href="https://boleizhou.github.io/" target="_blank" rel="noopener" class="rdi-spk-link-wrap">
             <div class="rdi-spk-avatar">
               <img src="../assets/images/agentic-summit-2026/speakers/bolei_zhou.png" alt="Bolei Zhou" loading="lazy" />
             </div>
             <p class="rdi-spk-name">Bolei Zhou</p>
-            <p class="rdi-spk-title">Associate Professor / Chief AI Scientist</p>
-            <p class="rdi-spk-org">UCLA / Coco Robotics</p>
+            <p class="rdi-spk-title">Associate Professor; Chief AI Scientist</p>
+            <p class="rdi-spk-org">UCLA; Coco Robotics</p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="rene pajta" data-org="microsoft" data-stage="atlas">
@@ -2676,14 +2676,14 @@
             <p class="rdi-spk-org">Airbyte</p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
-          <div class="rdi-spk-card" data-name="dan klein" data-org="uc berkeley / scaled cognition" data-stage="atlas">
+          <div class="rdi-spk-card" data-name="dan klein" data-org="uc berkeley; scaled cognition" data-stage="atlas">
             <a href="https://people.eecs.berkeley.edu/~klein/" target="_blank" rel="noopener" class="rdi-spk-link-wrap">
             <div class="rdi-spk-avatar">
               <img src="../assets/images/agentic-summit-2026/speakers/dan_klein.png" alt="Dan Klein" loading="lazy" />
             </div>
             <p class="rdi-spk-name">Dan Klein</p>
-            <p class="rdi-spk-title">Professor / Co-founder CTO</p>
-            <p class="rdi-spk-org">UC Berkeley / Scaled Cognition</p>
+            <p class="rdi-spk-title">Professor; Co-founder CTO</p>
+            <p class="rdi-spk-org">UC Berkeley; Scaled Cognition</p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="michal shmueli-scheuer" data-org="ibm research" data-stage="atlas">
@@ -2786,14 +2786,14 @@
             <p class="rdi-spk-org">Replit</p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
-          <div class="rdi-spk-card" data-name="markus j. buehler" data-org="mit/unreasonable labs" data-stage="nexus">
+          <div class="rdi-spk-card" data-name="markus j. buehler" data-org="mit; unreasonable labs" data-stage="nexus">
             <a href="https://lamm.mit.edu/" target="_blank" rel="noopener" class="rdi-spk-link-wrap">
             <div class="rdi-spk-avatar">
               <img src="../assets/images/agentic-summit-2026/speakers/markus_buehler.png" alt="Markus J. Buehler" loading="lazy" />
             </div>
             <p class="rdi-spk-name">Markus J. Buehler</p>
-            <p class="rdi-spk-title">Professor, Founder, CTO</p>
-            <p class="rdi-spk-org">MIT/Unreasonable Labs</p>
+            <p class="rdi-spk-title">Professor; Founder & CTO</p>
+            <p class="rdi-spk-org">MIT; Unreasonable Labs</p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="silas alberti" data-org="cognition" data-stage="nexus">
@@ -2886,14 +2886,14 @@
             <p class="rdi-spk-org">Diagnostic Robotics</p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
-          <div class="rdi-spk-card" data-name="bo li" data-org="virtue ai / uiuc" data-stage="nexus">
+          <div class="rdi-spk-card" data-name="bo li" data-org="virtue ai; uiuc" data-stage="nexus">
             <a href="https://www.linkedin.com/in/drboli" target="_blank" rel="noopener" class="rdi-spk-link-wrap">
             <div class="rdi-spk-avatar">
               <img src="../assets/images/agentic-summit-2026/speakers/bo_li.png" alt="Bo Li" loading="lazy" />
             </div>
             <p class="rdi-spk-name">Bo Li</p>
             <p class="rdi-spk-title">Co-Founder and CEO</p>
-            <p class="rdi-spk-org">Virtue AI / UIUC</p>
+            <p class="rdi-spk-org">Virtue AI; UIUC</p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="itsik mantin" data-org="intuit" data-stage="nexus">
@@ -3106,14 +3106,14 @@
             <p class="rdi-spk-org">Microsoft Corporation</p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
-          <div class="rdi-spk-card" data-name="yu su" data-org="neocognition / osu" data-stage="compass">
+          <div class="rdi-spk-card" data-name="yu su" data-org="neocognition; osu" data-stage="compass">
             <a href="https://ysu1989.github.io/" target="_blank" rel="noopener" class="rdi-spk-link-wrap">
             <div class="rdi-spk-avatar">
               <img src="../assets/images/agentic-summit-2026/speakers/yu_su.png" alt="Yu Su" loading="lazy" />
             </div>
             <p class="rdi-spk-name">Yu Su</p>
-            <p class="rdi-spk-title">CEO / Associate Professor</p>
-            <p class="rdi-spk-org">NeoCognition / OSU</p>
+            <p class="rdi-spk-title">CEO; Associate Professor</p>
+            <p class="rdi-spk-org">NeoCognition; OSU</p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="furong huang" data-org="university of maryland" data-stage="compass">
@@ -3136,14 +3136,14 @@
             <p class="rdi-spk-org">Tel Aviv University</p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
-          <div class="rdi-spk-card" data-name="lovedeep gondara" data-org="vanguard | university of british columbia" data-stage="compass">
+          <div class="rdi-spk-card" data-name="lovedeep gondara" data-org="vanguard; university of british columbia" data-stage="compass">
             <a href="https://lovedeepgondara.com/" target="_blank" rel="noopener" class="rdi-spk-link-wrap">
             <div class="rdi-spk-avatar">
               <img src="../assets/images/agentic-summit-2026/speakers/lovedeep_gondara.png" alt="Lovedeep Gondara" loading="lazy" />
             </div>
             <p class="rdi-spk-name">Lovedeep Gondara</p>
-            <p class="rdi-spk-title">Head of AI R&amp;D | Adjunct Professor</p>
-            <p class="rdi-spk-org">Vanguard | University of British Columbia</p>
+            <p class="rdi-spk-title">Head of AI R&amp;D; Adjunct Professor</p>
+            <p class="rdi-spk-org">Vanguard; University of British Columbia</p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="eric ho" data-org="goodfire" data-stage="compass">
@@ -3206,14 +3206,14 @@
             <p class="rdi-spk-org">Scale AI</p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
-          <div class="rdi-spk-card" data-name="chenguang wang" data-org="university of california, santa cruz / scale ai" data-stage="compass">
+          <div class="rdi-spk-card" data-name="chenguang wang" data-org="university of california, santa cruz; scale ai" data-stage="compass">
             <a href="https://cgraywang.github.io/" target="_blank" rel="noopener" class="rdi-spk-link-wrap">
             <div class="rdi-spk-avatar">
               <img src="../assets/images/agentic-summit-2026/speakers/chenguang_wang.png" alt="Chenguang Wang" loading="lazy" />
             </div>
             <p class="rdi-spk-name">Chenguang Wang</p>
-            <p class="rdi-spk-title">Assistant Professor / Research Advisor</p>
-            <p class="rdi-spk-org">University of California, Santa Cruz / Scale AI</p>
+            <p class="rdi-spk-title">Assistant Professor; Research Advisor</p>
+            <p class="rdi-spk-org">University of California, Santa Cruz; Scale AI</p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="karen ullrich" data-org="meta ai" data-stage="compass">
@@ -3286,14 +3286,14 @@
             <p class="rdi-spk-org">Trent AI</p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
-          <div class="rdi-spk-card" data-name="jordan jindong gu" data-org="google &amp; university of oxford" data-stage="compass">
+          <div class="rdi-spk-card" data-name="jordan jindong gu" data-org="google; university of oxford" data-stage="compass">
             <a href="https://jindonggu.github.io/" target="_blank" rel="noopener" class="rdi-spk-link-wrap">
             <div class="rdi-spk-avatar">
               <img src="../assets/images/agentic-summit-2026/speakers/jordan_gu.png" alt="Jordan Jindong Gu" loading="lazy" />
             </div>
             <p class="rdi-spk-name">Jordan Jindong Gu</p>
             <p class="rdi-spk-title">Senior Research Scientist</p>
-            <p class="rdi-spk-org">Google &amp; University of Oxford</p>
+            <p class="rdi-spk-org">Google; University of Oxford</p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="huan sun" data-org="the ohio state university" data-stage="compass">

--- a/events/agentic-ai-summit-2026.html
+++ b/events/agentic-ai-summit-2026.html
@@ -1863,8 +1863,8 @@
               <img src="../assets/images/agentic-summit-2026/speakers/ion_stoica.png" alt="Ion Stoica" loading="lazy" />
             </div>
             <p class="rdi-spk-name">Ion Stoica</p>
-            <p class="rdi-spk-title">Co-Founder; Professor</p>
-            <p class="rdi-spk-org">Databricks and Anyscale; UC Berkeley</p>
+            <p class="rdi-spk-title" style="margin:0 0 2px;">Co-Founder, <span style="color:#003262;font-weight:500;">Databricks and Anyscale</span></p>
+            <p class="rdi-spk-title" style="margin:0 0 10px;">Professor, <span style="color:#003262;font-weight:500;">UC Berkeley</span></p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="rich lyons" data-org="uc berkeley" data-stage="mainstage">
@@ -1883,8 +1883,8 @@
               <img src="../assets/images/agentic-summit-2026/speakers/dawn_song.jpg" alt="Dawn Song" loading="lazy" />
             </div>
             <p class="rdi-spk-name">Dawn Song</p>
-            <p class="rdi-spk-title">Professor; Co-Director</p>
-            <p class="rdi-spk-org">UC Berkeley; Berkeley RDI</p>
+            <p class="rdi-spk-title" style="margin:0 0 2px;">Professor, <span style="color:#003262;font-weight:500;">UC Berkeley</span></p>
+            <p class="rdi-spk-title" style="margin:0 0 10px;">Co-Director, <span style="color:#003262;font-weight:500;">Berkeley RDI</span></p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="wojciech zaremba" data-org="openai" data-stage="mainstage">
@@ -2153,8 +2153,9 @@
               <img src="../assets/images/agentic-summit-2026/speakers/andy_konwinski.png" alt="Andy Konwinski" loading="lazy" />
             </div>
             <p class="rdi-spk-name">Andy Konwinski</p>
-            <p class="rdi-spk-title">Co-Founder</p>
-            <p class="rdi-spk-org">Databricks; Perplexity; Laude Ventures</p>
+            <p class="rdi-spk-title" style="margin:0 0 2px;">Co-Founder, <span style="color:#003262;font-weight:500;">Databricks</span></p>
+            <p class="rdi-spk-title" style="margin:0 0 2px;"><span style="color:#003262;font-weight:500;">Perplexity</span></p>
+            <p class="rdi-spk-title" style="margin:0 0 10px;"><span style="color:#003262;font-weight:500;">Laude Ventures</span></p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="anjney midha" data-org="a16z" data-stage="mainstage">
@@ -2462,8 +2463,8 @@
               <img src="../assets/images/agentic-summit-2026/speakers/peter_stone.png" alt="Peter Stone" loading="lazy" />
             </div>
             <p class="rdi-spk-name">Peter Stone</p>
-            <p class="rdi-spk-title">Chief Scientist; Professor</p>
-            <p class="rdi-spk-org">Sony AI; UT Austin</p>
+            <p class="rdi-spk-title" style="margin:0 0 2px;">Chief Scientist, <span style="color:#003262;font-weight:500;">Sony AI</span></p>
+            <p class="rdi-spk-title" style="margin:0 0 10px;">Professor, <span style="color:#003262;font-weight:500;">UT Austin</span></p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="vincent vanhoucke" data-org="waymo" data-stage="atlas">
@@ -2572,8 +2573,8 @@
               <img src="../assets/images/agentic-summit-2026/speakers/sergei_gukov.png" alt="Sergei Gukov" loading="lazy" />
             </div>
             <p class="rdi-spk-name">Sergei Gukov</p>
-            <p class="rdi-spk-title">Executive Director; John D. MacArthur Professor of Theoretical Physics and Mathematics</p>
-            <p class="rdi-spk-org">American Institute of Mathematics; California Institute of Technology</p>
+            <p class="rdi-spk-title" style="margin:0 0 2px;">Executive Director, <span style="color:#003262;font-weight:500;">American Institute of Mathematics</span></p>
+            <p class="rdi-spk-title" style="margin:0 0 10px;">John D. MacArthur Professor of Theoretical Physics and Mathematics, <span style="color:#003262;font-weight:500;">California Institute of Technology</span></p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="tudor achim" data-org="harmonic" data-stage="atlas">
@@ -2632,8 +2633,8 @@
               <img src="../assets/images/agentic-summit-2026/speakers/bolei_zhou.png" alt="Bolei Zhou" loading="lazy" />
             </div>
             <p class="rdi-spk-name">Bolei Zhou</p>
-            <p class="rdi-spk-title">Associate Professor; Chief AI Scientist</p>
-            <p class="rdi-spk-org">UCLA; Coco Robotics</p>
+            <p class="rdi-spk-title" style="margin:0 0 2px;">Associate Professor, <span style="color:#003262;font-weight:500;">UCLA</span></p>
+            <p class="rdi-spk-title" style="margin:0 0 10px;">Chief AI Scientist, <span style="color:#003262;font-weight:500;">Coco Robotics</span></p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="rene pajta" data-org="microsoft" data-stage="atlas">
@@ -2682,8 +2683,8 @@
               <img src="../assets/images/agentic-summit-2026/speakers/dan_klein.png" alt="Dan Klein" loading="lazy" />
             </div>
             <p class="rdi-spk-name">Dan Klein</p>
-            <p class="rdi-spk-title">Professor; Co-founder CTO</p>
-            <p class="rdi-spk-org">UC Berkeley; Scaled Cognition</p>
+            <p class="rdi-spk-title" style="margin:0 0 2px;">Professor, <span style="color:#003262;font-weight:500;">UC Berkeley</span></p>
+            <p class="rdi-spk-title" style="margin:0 0 10px;">Co-founder CTO, <span style="color:#003262;font-weight:500;">Scaled Cognition</span></p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="michal shmueli-scheuer" data-org="ibm research" data-stage="atlas">
@@ -2792,8 +2793,8 @@
               <img src="../assets/images/agentic-summit-2026/speakers/markus_buehler.png" alt="Markus J. Buehler" loading="lazy" />
             </div>
             <p class="rdi-spk-name">Markus J. Buehler</p>
-            <p class="rdi-spk-title">Professor; Founder & CTO</p>
-            <p class="rdi-spk-org">MIT; Unreasonable Labs</p>
+            <p class="rdi-spk-title" style="margin:0 0 2px;">Professor, <span style="color:#003262;font-weight:500;">MIT</span></p>
+            <p class="rdi-spk-title" style="margin:0 0 10px;">Founder & CTO, <span style="color:#003262;font-weight:500;">Unreasonable Labs</span></p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="silas alberti" data-org="cognition" data-stage="nexus">
@@ -2892,8 +2893,8 @@
               <img src="../assets/images/agentic-summit-2026/speakers/bo_li.png" alt="Bo Li" loading="lazy" />
             </div>
             <p class="rdi-spk-name">Bo Li</p>
-            <p class="rdi-spk-title">Co-Founder and CEO</p>
-            <p class="rdi-spk-org">Virtue AI; UIUC</p>
+            <p class="rdi-spk-title" style="margin:0 0 2px;">Co-Founder and CEO, <span style="color:#003262;font-weight:500;">Virtue AI</span></p>
+            <p class="rdi-spk-title" style="margin:0 0 10px;"><span style="color:#003262;font-weight:500;">UIUC</span></p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="itsik mantin" data-org="intuit" data-stage="nexus">
@@ -3112,8 +3113,8 @@
               <img src="../assets/images/agentic-summit-2026/speakers/yu_su.png" alt="Yu Su" loading="lazy" />
             </div>
             <p class="rdi-spk-name">Yu Su</p>
-            <p class="rdi-spk-title">CEO; Associate Professor</p>
-            <p class="rdi-spk-org">NeoCognition; OSU</p>
+            <p class="rdi-spk-title" style="margin:0 0 2px;">CEO, <span style="color:#003262;font-weight:500;">NeoCognition</span></p>
+            <p class="rdi-spk-title" style="margin:0 0 10px;">Associate Professor, <span style="color:#003262;font-weight:500;">OSU</span></p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="furong huang" data-org="university of maryland" data-stage="compass">
@@ -3142,8 +3143,8 @@
               <img src="../assets/images/agentic-summit-2026/speakers/lovedeep_gondara.png" alt="Lovedeep Gondara" loading="lazy" />
             </div>
             <p class="rdi-spk-name">Lovedeep Gondara</p>
-            <p class="rdi-spk-title">Head of AI R&amp;D; Adjunct Professor</p>
-            <p class="rdi-spk-org">Vanguard; University of British Columbia</p>
+            <p class="rdi-spk-title" style="margin:0 0 2px;">Head of AI R&amp;D, <span style="color:#003262;font-weight:500;">Vanguard</span></p>
+            <p class="rdi-spk-title" style="margin:0 0 10px;">Adjunct Professor, <span style="color:#003262;font-weight:500;">University of British Columbia</span></p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="eric ho" data-org="goodfire" data-stage="compass">
@@ -3212,8 +3213,8 @@
               <img src="../assets/images/agentic-summit-2026/speakers/chenguang_wang.png" alt="Chenguang Wang" loading="lazy" />
             </div>
             <p class="rdi-spk-name">Chenguang Wang</p>
-            <p class="rdi-spk-title">Assistant Professor; Research Advisor</p>
-            <p class="rdi-spk-org">University of California, Santa Cruz; Scale AI</p>
+            <p class="rdi-spk-title" style="margin:0 0 2px;">Assistant Professor, <span style="color:#003262;font-weight:500;">University of California, Santa Cruz</span></p>
+            <p class="rdi-spk-title" style="margin:0 0 10px;">Research Advisor, <span style="color:#003262;font-weight:500;">Scale AI</span></p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="karen ullrich" data-org="meta ai" data-stage="compass">
@@ -3292,8 +3293,8 @@
               <img src="../assets/images/agentic-summit-2026/speakers/jordan_gu.png" alt="Jordan Jindong Gu" loading="lazy" />
             </div>
             <p class="rdi-spk-name">Jordan Jindong Gu</p>
-            <p class="rdi-spk-title">Senior Research Scientist</p>
-            <p class="rdi-spk-org">Google; University of Oxford</p>
+            <p class="rdi-spk-title" style="margin:0 0 2px;">Senior Research Scientist, <span style="color:#003262;font-weight:500;">Google</span></p>
+            <p class="rdi-spk-title" style="margin:0 0 10px;"><span style="color:#003262;font-weight:500;">University of Oxford</span></p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="huan sun" data-org="the ohio state university" data-stage="compass">


### PR DESCRIPTION
Standardizes how speakers with two titles/orgs are displayed
Agenda timeline: each dual-affiliation speaker now shows as
"title 1, org 1; title 2, org 2" on a single line
(e.g. "Associate Professor, UCLA; Chief AI Scientist, Coco Robotics").

Speaker cards: each affiliation renders on its own line as "Title, Org"
with the org in the brand blue, instead of positionally-paired
"title; title" over "org; org". This removes the ambiguity of aligning
roles to orgs and matches standard professional bio formatting.

Speakers updated (13):
- Bolei Zhou, Dan Klein, Yu Su, Chenguang Wang, Markus J. Buehler,
  Sergei Gukov - dual title + dual org
- Ion Stoica, Peter Stone, Dawn Song - agenda corrected to interleaved
  format (cards were already correct)
- Bo Li, Andy Konwinski, Jordan Jindong Gu - single title across multiple
  orgs (title pairs with first org, additional orgs on their own line)
- Lovedeep Gondara - pipe-separated dual title/org
