### PR TITLE
Agentic AI Summit 2026: add Startup Spotlight application box

### DIFF
--- a/events/agentic-ai-summit-2026.html
+++ b/events/agentic-ai-summit-2026.html
@@ -200,6 +200,18 @@
       </div>
 
       <div style="margin: 30px 0; padding: 20px; background-color: #f8f9fa; border-left: 4px solid #CB9445; border-radius: 4px;">
+        <h3 style="color: #CB9445; font-weight: 700; font-size: 20px; margin-bottom: 15px; margin-top: 0;">Startup Spotlight</h3>
+        <p style="font-size: 1rem; margin-bottom: 20px;">
+          Building something exciting in Agentic AI? Apply to pitch directly to 5,000+ decision-makers, investors, and practitioners in the room and hundreds of thousands watching worldwide.
+        </p>
+        <div style="text-align: center;">
+          <button class="styled-button" onclick="location.href='https://docs.google.com/forms/d/e/1FAIpQLSdxQs2J-MyrtTZJMCaZJL0FWmds_f4jvLFp0dlEDsD8NR00Ng/viewform'">
+            Startup Spotlight Application
+          </button>
+        </div>
+      </div>
+
+      <div style="margin: 30px 0; padding: 20px; background-color: #f8f9fa; border-left: 4px solid #CB9445; border-radius: 4px;">
         <h3 style="color: #CB9445; font-weight: 700; font-size: 20px; margin-bottom: 15px; margin-top: 0;">Sponsorship Opportunities</h3>
         <p style="font-size: 1rem; margin-bottom: 20px;">
           Partner with us to shape the future of Agentic AI. Interested in sponsoring the summit? Please fill out the sponsorship application form.


### PR DESCRIPTION
Adds a Startup Spotlight application box between the Early-Bird Pricing box and the Sponsorship Opportunities box, per Linda.

- Same box styling as the surrounding ticketing/sponsorship boxes (gold-accent, styled-button).
- Links to the Startup Spotlight application form.
- Wording from Dawn Song's announcement tweet.