### PR TITLE
Agentic AI Summit 2026: correct Duncan Lennox org spelling to HubSpot

### DIFF
--- a/events/agentic-ai-summit-2026.html
+++ b/events/agentic-ai-summit-2026.html
@@ -627,7 +627,7 @@
                   <div class="speaker">
                       <div class="speaker-header">
                           <div class="speaker-name">Duncan Lennox</div>
-                          <div class="speaker-title">Chief Product &amp; Technology Officer, Hubspot</div>
+                          <div class="speaker-title">Chief Product &amp; Technology Officer, HubSpot</div>
                       </div>
                   </div>
                   <div class="speaker">
@@ -2228,7 +2228,7 @@
             </div>
             <p class="rdi-spk-name">Duncan Lennox</p>
             <p class="rdi-spk-title">Chief Product & Technology Officer</p>
-            <p class="rdi-spk-org">Hubspot</p>
+            <p class="rdi-spk-org">HubSpot</p>
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
           <div class="rdi-spk-card" data-name="jeff wecker" data-org="two sigma" data-stage="mainstage">


### PR DESCRIPTION
Corrects Duncan Lennox's company from "Hubspot" to "HubSpot" in his agenda entry and speaker card, per HubSpot's request.