### PR TITLE
Agentic AI Summit 2026: remove sponsorship application

### DIFF
--- a/events/agentic-ai-summit-2026.html
+++ b/events/agentic-ai-summit-2026.html
@@ -211,18 +211,6 @@
         </div>
       </div>
 
-      <div style="margin: 30px 0; padding: 20px; background-color: #f8f9fa; border-left: 4px solid #CB9445; border-radius: 4px;">
-        <h3 style="color: #CB9445; font-weight: 700; font-size: 20px; margin-bottom: 15px; margin-top: 0;">Sponsorship Opportunities</h3>
-        <p style="font-size: 1rem; margin-bottom: 20px;">
-          Partner with us to shape the future of Agentic AI. Interested in sponsoring the summit? Please fill out the sponsorship application form.
-        </p>
-        <div style="text-align: center;">
-          <button class="styled-button" onclick="location.href='https://forms.gle/ZmfSDBVVXFhMvRAk8'">
-            Sponsorship Application
-          </button>
-        </div>
-      </div>
-
       <div class="agenda-section" style="margin: 30px 0;">
         <hr style="margin-left: -20%; margin-right: -20%">
         <br>
@@ -731,12 +719,6 @@
                   <div class="event-title">Focus Talks</div>
                   <div class="speaker">
                       <div class="speaker-header">
-                          <div class="speaker-name">Lukas Biewald</div>
-                          <div class="speaker-title">Founder/CEO, Weights &amp; Biases</div>
-                      </div>
-                  </div>
-                  <div class="speaker">
-                      <div class="speaker-header">
                           <div class="speaker-name">Matt White</div>
                           <div class="speaker-title">Global CTO of AI, Linux Foundation; CTO, PyTorch Foundation</div>
                       </div>
@@ -747,7 +729,7 @@
               <div class="event-time">2:20 PM</div>
               <div class="event-content">
                   <div class="event-title">Panel: Agentic AI Developer Platforms</div>
-                  <div class="moderator">Panelists: Lukas Biewald, Matt White, Dima Dmytro Dzhulgakov (Co-Founder/CTO, Fireworks AI), Ivan Burazin (Co-Founder/CEO, Daytona)</div>
+                  <div class="moderator">Panelists: Matt White, Dima Dmytro Dzhulgakov (Co-Founder/CTO, Fireworks AI), Ivan Burazin (Co-Founder/CEO, Daytona)</div>
                   <div class="moderator">Moderator: Megan Morrone (Editor of Technology, Axios)</div>
               </div>
           </div>
@@ -2209,16 +2191,6 @@
             
             <span class="rdi-spk-link">View profile →</span></a>
           </div>
-          <div class="rdi-spk-card" data-name="lukas biewald" data-org="weights & biases" data-stage="mainstage">
-            <a href="https://lukasbiewald.com/" target="_blank" rel="noopener" class="rdi-spk-link-wrap">
-            <div class="rdi-spk-avatar">
-              <img src="../assets/images/agentic-summit-2026/speakers/lukas_biewald.png" alt="Lukas Biewald" loading="lazy" />
-            </div>
-            <p class="rdi-spk-name">Lukas Biewald</p>
-            <p class="rdi-spk-title">Founder/CEO</p>
-            <p class="rdi-spk-org">Weights & Biases</p>
-            <span class="rdi-spk-link">View profile →</span></a>
-          </div>
           <div class="rdi-spk-card" data-name="chuan li" data-org="lambda" data-stage="mainstage">
             <a href="https://github.com/chuanli11" target="_blank" rel="noopener" class="rdi-spk-link-wrap">
             <div class="rdi-spk-avatar">
@@ -3665,12 +3637,6 @@
         <p style="text-align: center; color: #999; font-size: 14px; font-style: italic; margin-top: 28px;">
           More sponsors to be announced soon...
         </p>
-
-        <div style="text-align: center; margin-top: 24px; padding-top: 24px;">
-          <button class="styled-button" onclick="location.href='https://forms.gle/ZmfSDBVVXFhMvRAk8'">
-            Become a Sponsor
-          </button>
-        </div>
 
         <div style="margin: 30px 0 0; padding: 20px; background-color: #f8f9fa; border-left: 4px solid #CB9445; border-radius: 4px;">
           <h3 style="color: #CB9445; font-weight: 700; font-size: 20px; margin-bottom: 15px; margin-top: 0;">Hosting a Side Event?</h3>


### PR DESCRIPTION
Removes the sponsorship application (summit is at capacity) and Lukas Biewald (cannot attend), per Linda.

- Remove the "Sponsorship Opportunities" box and the "Become a Sponsor" button.
- Remove Lukas Biewald from the Plenary Sunday agenda (Focus Talk and panelist list) and his speaker card. The panel keeps its other panelists (Matt White, Dima Dmytro Dzhulgakov, Ivan Burazin) and moderator.