### PR TITLE
Add Side Events section above Community Partners

### DIFF
--- a/events/agentic-ai-summit-2026.html
+++ b/events/agentic-ai-summit-2026.html
@@ -226,6 +226,19 @@
         </div>
       </div>
 
+      
+      <div style="margin: 30px 0; padding: 20px; background-color: #f8f9fa; border-left: 4px solid #CB9445; border-radius: 4px;">
+        <h3 style="color: #CB9445; font-weight: 700; font-size: 20px; margin-bottom: 15px; margin-top: 0;">Side Events</h3>
+        <p style="font-size: 1rem; margin-bottom: 20px;">
+          Community-hosted meetups, workshops, and gatherings are happening all around the Summit, from July 30 through August 4. Take a look at what is on.
+        </p>
+        <div style="text-align: center;">
+          <button class="styled-button" onclick="document.getElementById('side-events').scrollIntoView({behavior:'smooth', block:'start'});">
+            View Side Events
+          </button>
+        </div>
+      </div>
+
       <div class="agenda-section" style="margin: 30px 0;">
         <hr style="margin-left: -20%; margin-right: -20%">
         <br>
@@ -3657,6 +3670,16 @@
         <p style="text-align: center; color: #999; font-size: 14px; font-style: italic; margin-top: 28px;">
           More sponsors to be announced soon...
         </p>
+
+        
+        <!-- Side Events -->
+        <div id="side-events" style="scroll-margin-top: 80px;"></div>
+<hr style="margin: 40px 0 30px;">
+<h1 style="font-weight: 500; color: #CB9445; text-align: center; font-size: 40px">Side Events</h1>
+<p style="text-align: center; color: #666; font-size: 14px; margin-bottom: 30px;">Independently organized meetups and gatherings happening around the Summit.</p>
+<style>.se-pill{font-size:10.5px;font-weight:700;letter-spacing:.5px;text-transform:uppercase;padding:4px 9px;border-radius:999px;white-space:nowrap;}.se-pill--free{color:#1a7f4f;background:#e6f4ec;}.se-pill--invite{color:#8a6320;background:#f6ecd7;}.se-pill--tkt{color:#1a5fb4;background:#e7eef7;}.se-btn{display:inline-block;padding:9px 18px;border:solid .5px #30303060;border-radius:5px;background:#CB9445;font-weight:700;font-size:.82rem;text-align:center;cursor:pointer;transition:background-color .3s;}#main-text-container a.se-btn{color:#fff;text-decoration:none;}#main-text-container a.se-btn:hover{color:#fff;text-decoration:none;background:#dcbf72;}#main-text-container a.se-textlink{color:#CB9445;font-weight:700;font-size:.82rem;text-decoration:none;white-space:nowrap;}#main-text-container a.se-textlink:hover{text-decoration:underline;color:#CB9445;}.se-c-wrap{max-width:860px;margin:0 auto;}.se-c-row{display:grid;grid-template-columns:64px minmax(0,1fr) 116px 132px;gap:18px;align-items:center;padding:15px 6px;border-bottom:1px solid #ececec;}.se-c-row:first-child{border-top:1px solid #ececec;}.se-c-badge{background:#CB9445;color:#fff;border-radius:8px;text-align:center;padding:8px 0;}.se-c-badge .m{font-size:10.5px;font-weight:700;text-transform:uppercase;letter-spacing:.5px;}.se-c-badge .d{font-size:19px;font-weight:700;line-height:1;}.se-c-name{font-size:15px;font-weight:700;color:#1c2530;}.se-c-host{font-size:12.5px;color:#666;margin-top:2px;}.se-c-access{display:flex;justify-content:flex-end;}.se-c-cta{display:flex;justify-content:flex-end;}@media(max-width:640px){.se-c-row{grid-template-columns:56px 1fr;row-gap:10px;}.se-c-access,.se-c-cta{grid-column:2;justify-content:flex-start;}}</style><div class="se-c-wrap"><div class="se-c-row"><div class="se-c-badge"><div class="m">JUL</div><div class="d">30</div></div><div><div class="se-c-name">AI &amp; Science Happy Hour</div><div class="se-c-host">Valency &middot; 5:30 PM &middot; Berkeley</div></div><div class="se-c-access"><span class="se-pill se-pill--invite">Invite-only</span></div><div class="se-c-cta"><a class="se-textlink" href="https://events.valency.io/july-hh" target="_blank" rel="noopener">Request invite &rsaquo;</a></div></div><div class="se-c-row"><div class="se-c-badge"><div class="m">JUL</div><div class="d">31</div></div><div><div class="se-c-name">Controls for the Agentic Enterprise</div><div class="se-c-host">SafeAlign AI &amp; COHUMAIN Labs, with USF &middot; 4:30 PM &middot; San Francisco</div></div><div class="se-c-access"><span class="se-pill se-pill--free">Free</span></div><div class="se-c-cta"><a class="se-textlink" href="https://luma.com/uu0hnz52" target="_blank" rel="noopener">RSVP &rsaquo;</a></div></div><div class="se-c-row"><div class="se-c-badge"><div class="m">AUG</div><div class="d">1</div></div><div><div class="se-c-name">Agent Infrastructure Roundtable 2026</div><div class="se-c-host">ARAMAS AI &amp; Berkeley Gateway Accelerator &middot; 6:30 to 9:00 PM &middot; Berkeley</div></div><div class="se-c-access"><span class="se-pill se-pill--invite">Invite-only</span></div><div class="se-c-cta"><a class="se-textlink" href="https://luma.com/9k0g4dqj" target="_blank" rel="noopener">Request invite &rsaquo;</a></div></div><div class="se-c-row"><div class="se-c-badge"><div class="m">AUG</div><div class="d">4</div></div><div><div class="se-c-name">Socratic Agentic AI Summit, Berkeley</div><div class="se-c-host">AI Socratic &middot; 6:00 to 9:00 PM &middot; Berkeley</div></div><div class="se-c-access"><span class="se-pill se-pill--tkt">Ticketed</span></div><div class="se-c-cta"><a class="se-textlink" href="https://luma.com/berkeley-socratic" target="_blank" rel="noopener">Get tickets &rsaquo;</a></div></div></div>
+<p style="text-align: center; color: #999; font-size: 14px; font-style: italic; margin-top: 28px;">More side events to be announced soon...</p>
+<p style="text-align: center; color: #999; font-size: 12.5px; font-style: italic; margin-top: 10px;">Side events are independently organized and not officially hosted by Berkeley RDI or RDI Foundation.</p>
 
         <!-- Community Partners -->
         <hr style="margin: 40px 0 30px;">


### PR DESCRIPTION
Adds a Side Events section to the Agentic AI Summit 2026 page, listing the four approved community side events, placed directly above Our Community Partners.

- Compact list: date, event, host, city, and access (free, invite-only, or ticketed), each linking out to its event page.
- Locations show city only (Berkeley or San Francisco), with a "More side events to be announced soon..." line below the list.
- Adds a Side Events call-out after Startup Spotlight with a "View Side Events" button that smooth-scrolls down to the section, so attendees can find it without scrolling the whole page.

Section carries the standard note that side events are independently organized and not officially hosted by Berkeley RDI.