### PR TITLE
Add site-wide livestream promo banner

### DIFF
--- a/_includes/promo-banner.html
+++ b/_includes/promo-banner.html
@@ -1,10 +1,3 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="refresh" content="0; url=https://rdi.berkeley.edu/events/agentic-ai-summit-2026">
-</head>
-<body>
 <!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
 <style>header.sticky{top:var(--rdi-banner-h,42px)!important}</style>
 <div id="rdi-promo-banner" style="position:sticky;top:0;z-index:9999;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
@@ -12,5 +5,4 @@
 <button onclick="document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px');try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
 </div>
 <script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px')}}catch(e){}</script>
-<!-- /RDI LIVESTREAM PROMO BANNER --></body>
-</html>
+<!-- /RDI LIVESTREAM PROMO BANNER -->

--- a/_layouts/academics.html
+++ b/_layouts/academics.html
@@ -65,6 +65,7 @@
   </style>
 </head>
 <body class="text-gray-800">
+{%- include promo-banner.html -%}
 
 <!-- Header (matching homepage) -->
 <header class="sticky top-0 bg-white shadow z-50">

--- a/_layouts/blog-listing.html
+++ b/_layouts/blog-listing.html
@@ -11,6 +11,7 @@
   <script async src="https://siteimproveanalytics.com/js/siteanalyze_6294756.js"></script>
 </head>
 <body class="text-gray-800">
+{%- include promo-banner.html -%}
 
 <header class="sticky top-0 bg-white shadow z-50">
   <div class="max-w-7xl mx-auto flex justify-between items-center px-6 py-4">

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -7,6 +7,7 @@
 </head>
 
 <body data-new-gr-c-s-check-loaded="14.1034.0" data-gr-ext-installed="">
+{%- include promo-banner.html -%}
 
 <!-- Header (matching homepage) -->
 <header class="sticky top-0 bg-white shadow z-50">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,6 +4,7 @@
 {%- include head.html -%}
 
 <body data-new-gr-c-s-check-loaded="14.1034.0" data-gr-ext-installed="">
+{%- include promo-banner.html -%}
 
     {%- include nav.html -%}
 

--- a/_layouts/events.html
+++ b/_layouts/events.html
@@ -11,6 +11,7 @@
   <script async src="https://siteimproveanalytics.com/js/siteanalyze_6294756.js"></script>
 </head>
 <body class="text-gray-800">
+{%- include promo-banner.html -%}
 
 <header class="sticky top-0 bg-white shadow z-50">
   <div class="max-w-7xl mx-auto flex justify-between items-center px-6 py-4">

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -41,6 +41,7 @@
   </style>
 </head>
 <body class="text-gray-800">
+{%- include promo-banner.html -%}
 
 <header class="sticky top-0 bg-white shadow z-50">
   <div class="max-w-7xl mx-auto flex justify-between items-center px-6 py-4">

--- a/_layouts/otherevents.html
+++ b/_layouts/otherevents.html
@@ -31,6 +31,7 @@
   <script async src=”https://siteimproveanalytics.com/js/siteanalyze_6294756.js”></script>
 </head>
 <body class="text-gray-800">
+{%- include promo-banner.html -%}
 
 <header class="sticky top-0 bg-white shadow z-50">
   <div class="max-w-7xl mx-auto flex justify-between items-center px-6 py-4">

--- a/_layouts/people.html
+++ b/_layouts/people.html
@@ -11,6 +11,7 @@
   <script async src="https://siteimproveanalytics.com/js/siteanalyze_6294756.js"></script>
 </head>
 <body class="text-gray-800">
+{%- include promo-banner.html -%}
 
 <header class="sticky top-0 bg-white shadow z-50">
   <div class="max-w-7xl mx-auto flex justify-between items-center px-6 py-4">

--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -120,6 +120,7 @@
   </style>
 </head>
 <body class="text-gray-800">
+{%- include promo-banner.html -%}
 
 <header class="sticky top-0 bg-white shadow z-50">
   <div class="max-w-7xl mx-auto flex justify-between items-center px-6 py-4">

--- a/agentx-agentbeats.html
+++ b/agentx-agentbeats.html
@@ -598,6 +598,14 @@
 </head>
 
 <body>
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<style>header.sticky{top:var(--rdi-banner-h,42px)!important}</style>
+<div id="rdi-promo-banner" style="position:sticky;top:0;z-index:9999;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px');try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px')}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
   <a class="sr-only" href="#content">Skip to the content.</a>
 
   <section class="banner">

--- a/events/agentic-ai-summit-2025.html
+++ b/events/agentic-ai-summit-2025.html
@@ -92,6 +92,14 @@
 </div>
 
 <body data-new-gr-c-s-check-loaded="14.1034.0" data-gr-ext-installed="">
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<style>header.sticky{top:var(--rdi-banner-h,42px)!important}</style>
+<div id="rdi-promo-banner" style="position:sticky;top:0;z-index:9999;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px');try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px')}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
 
   <div style="border: 2px solid #4CAF50; padding: 15px; background-color: #E9F8E8; max-width: 725px; margin: 0 auto;">
     <p style="font-size: 24px; font-weight: bold; color: #4CAF50; margin: 0 0 8px 0;">Announcement:</p>

--- a/events/agentic-ai-summit-2026.html
+++ b/events/agentic-ai-summit-2026.html
@@ -82,6 +82,14 @@
 </header>
 
 <body data-new-gr-c-s-check-loaded="14.1034.0" data-gr-ext-installed="">
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<style>header.sticky{top:var(--rdi-banner-h,42px)!important}</style>
+<div id="rdi-promo-banner" style="position:sticky;top:0;z-index:9999;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px');try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px')}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
 
   <style>
     #agentic-2026-banner { margin-left: 17vw; margin-right: 17vw; width: calc(100% - 34vw); }

--- a/events/decentralizationaisummit.html
+++ b/events/decentralizationaisummit.html
@@ -90,6 +90,14 @@
 </div>
 
 <body data-new-gr-c-s-check-loaded="14.1034.0" data-gr-ext-installed="">
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<style>header.sticky{top:var(--rdi-banner-h,42px)!important}</style>
+<div id="rdi-promo-banner" style="position:sticky;top:0;z-index:9999;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px');try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px')}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
 
   <img src="https://rdi.berkeley.edu/assets/images/events/SBC_Berkeley_Day_Banner_Standard.png" alt=""
     style="display:block; margin:auto; max-width:80%; height:auto; margin-top: 2%; margin-bottom: 2%;">

--- a/events/decentralizationaisummit24.html
+++ b/events/decentralizationaisummit24.html
@@ -92,6 +92,14 @@
 </div>
 
 <body data-new-gr-c-s-check-loaded="14.1034.0" data-gr-ext-installed="">
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<style>header.sticky{top:var(--rdi-banner-h,42px)!important}</style>
+<div id="rdi-promo-banner" style="position:sticky;top:0;z-index:9999;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px');try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px')}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
 
   <img src="./sbc-assets/images/decentralizationaisummit24-v2.png" alt=""
     style="display:block; margin:auto; max-width:80%; height:auto; margin-top: 2%; margin-bottom: 2%;">

--- a/events/decentralizationaisummit25.html
+++ b/events/decentralizationaisummit25.html
@@ -176,6 +176,14 @@
 
 <script async src=”https://siteimproveanalytics.com/js/siteanalyze_6294756.js”></script>
 <body data-new-gr-c-s-check-loaded="14.1034.0" data-gr-ext-installed="">
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<style>header.sticky{top:var(--rdi-banner-h,42px)!important}</style>
+<div id="rdi-promo-banner" style="position:sticky;top:0;z-index:9999;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px');try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px')}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
 
   <img src="./sbc-assets/images/decentralizationaisummit25.jpg" alt=""
     style="display:block; margin:auto; max-width:80%; height:auto; margin-top: 2%; margin-bottom: 2%;">

--- a/events/zkpcareerfair.html
+++ b/events/zkpcareerfair.html
@@ -17,6 +17,14 @@
 
 </head>
 <body data-new-gr-c-s-check-loaded="14.1034.0" data-gr-ext-installed="">
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<style>header.sticky{top:var(--rdi-banner-h,42px)!important}</style>
+<div id="rdi-promo-banner" style="position:sticky;top:0;z-index:9999;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px');try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px')}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
 
     <div class="features-wrapper constraint">
 

--- a/xcelerator.html
+++ b/xcelerator.html
@@ -197,6 +197,14 @@
 </head>
 
 <body data-new-gr-c-s-check-loaded="14.1034.0" data-gr-ext-installed="">
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<style>header.sticky{top:var(--rdi-banner-h,42px)!important}</style>
+<div id="rdi-promo-banner" style="position:sticky;top:0;z-index:9999;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px');try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px')}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
 
     <!-- Header Navigation -->
     <header class="sticky top-0 bg-white shadow z-50">


### PR DESCRIPTION
Adds the livestream promo banner Linda approved (mock option B) across the RDI site, per her request in Slack.

- New shared include: _includes/promo-banner.html - gold bar, sticky at top, "Watch Live: Agentic AI Summit 2026 — RSVP Now", links to https://luma.com/livestream-agenticaisummit, dismissible with an X (dismissal persists across pages via localStorage)
- Included in all 9 Jekyll layouts right after <body> (home.html inherits via default), covering every layout-rendered page
- Injected directly into 9 standalone full-HTML pages that don't use layouts: the 2026/2025/original summit pages, the DeAI summit pages, ZKP career fair, Xcelerator, and AgentX
- Sticky-header offset is scoped to the Tailwind header pattern so the summit page header tucks under the banner; no-op elsewhere
- The banner block is comment-marked for easy removal after the Summit

Verified with a full Jekyll build: site compiles, every rendered page shows exactly one banner (including academics/RDI-certificate.html, which uses layout: default and is not double-injected). A handful of deep-legacy pages (zkp-workshop-2022 mirror, old course pages, cesc.html) intentionally not covered.