### PR TITLE
Fix promo banner overlapping site navigation

### DIFF
--- a/_includes/promo-banner.html
+++ b/_includes/promo-banner.html
@@ -1,8 +1,7 @@
 <!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
-<style>header.sticky{top:var(--rdi-banner-h,42px)!important}</style>
-<div id="rdi-promo-banner" style="position:sticky;top:0;z-index:9999;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<div id="rdi-promo-banner" style="position:relative;z-index:40;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
 <a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
-<button onclick="document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px');try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
 </div>
-<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px')}}catch(e){}</script>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none'}}catch(e){}</script>
 <!-- /RDI LIVESTREAM PROMO BANNER -->

--- a/agentx-agentbeats.html
+++ b/agentx-agentbeats.html
@@ -596,16 +596,15 @@
     :target::before { content:""; display:block; height: 0; margin-top: 0; visibility: hidden; }
   </style>
 </head>
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<div id="rdi-promo-banner" style="position:relative;z-index:40;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none'}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
 
 <body>
-<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
-<style>header.sticky{top:var(--rdi-banner-h,42px)!important}</style>
-<div id="rdi-promo-banner" style="position:sticky;top:0;z-index:9999;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
-<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
-<button onclick="document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px');try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
-</div>
-<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px')}}catch(e){}</script>
-<!-- /RDI LIVESTREAM PROMO BANNER -->
   <a class="sr-only" href="#content">Skip to the content.</a>
 
   <section class="banner">

--- a/events/agentic-ai-summit-2025.html
+++ b/events/agentic-ai-summit-2025.html
@@ -36,6 +36,13 @@
     });
   </script>
 </head>
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<div id="rdi-promo-banner" style="position:relative;z-index:40;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none'}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
 
 <div class="constraint">
   <div id="header">
@@ -92,14 +99,6 @@
 </div>
 
 <body data-new-gr-c-s-check-loaded="14.1034.0" data-gr-ext-installed="">
-<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
-<style>header.sticky{top:var(--rdi-banner-h,42px)!important}</style>
-<div id="rdi-promo-banner" style="position:sticky;top:0;z-index:9999;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
-<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
-<button onclick="document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px');try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
-</div>
-<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px')}}catch(e){}</script>
-<!-- /RDI LIVESTREAM PROMO BANNER -->
 
   <div style="border: 2px solid #4CAF50; padding: 15px; background-color: #E9F8E8; max-width: 725px; margin: 0 auto;">
     <p style="font-size: 24px; font-weight: bold; color: #4CAF50; margin: 0 0 8px 0;">Announcement:</p>

--- a/events/agentic-ai-summit-2026.html
+++ b/events/agentic-ai-summit-2026.html
@@ -40,6 +40,13 @@
     });
   </script>
 </head>
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<div id="rdi-promo-banner" style="position:relative;z-index:40;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none'}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
 
 <header class="sticky top-0 bg-white shadow z-50">
   <div class="max-w-7xl mx-auto flex justify-between items-center px-6 py-4">
@@ -82,14 +89,6 @@
 </header>
 
 <body data-new-gr-c-s-check-loaded="14.1034.0" data-gr-ext-installed="">
-<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
-<style>header.sticky{top:var(--rdi-banner-h,42px)!important}</style>
-<div id="rdi-promo-banner" style="position:sticky;top:0;z-index:9999;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
-<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
-<button onclick="document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px');try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
-</div>
-<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px')}}catch(e){}</script>
-<!-- /RDI LIVESTREAM PROMO BANNER -->
 
   <style>
     #agentic-2026-banner { margin-left: 17vw; margin-right: 17vw; width: calc(100% - 34vw); }

--- a/events/agentic-ai-summit.html
+++ b/events/agentic-ai-summit.html
@@ -4,13 +4,13 @@
   <meta charset="UTF-8">
   <meta http-equiv="refresh" content="0; url=https://rdi.berkeley.edu/events/agentic-ai-summit-2026">
 </head>
-<body>
 <!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
-<style>header.sticky{top:var(--rdi-banner-h,42px)!important}</style>
-<div id="rdi-promo-banner" style="position:sticky;top:0;z-index:9999;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<div id="rdi-promo-banner" style="position:relative;z-index:40;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
 <a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
-<button onclick="document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px');try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
 </div>
-<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px')}}catch(e){}</script>
-<!-- /RDI LIVESTREAM PROMO BANNER --></body>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none'}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
+<body>
+</body>
 </html>

--- a/events/decentralizationaisummit.html
+++ b/events/decentralizationaisummit.html
@@ -35,6 +35,13 @@
     });
   </script>
 </head>
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<div id="rdi-promo-banner" style="position:relative;z-index:40;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none'}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
 
 <div class="constraint">
   <div id="header">
@@ -90,14 +97,6 @@
 </div>
 
 <body data-new-gr-c-s-check-loaded="14.1034.0" data-gr-ext-installed="">
-<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
-<style>header.sticky{top:var(--rdi-banner-h,42px)!important}</style>
-<div id="rdi-promo-banner" style="position:sticky;top:0;z-index:9999;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
-<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
-<button onclick="document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px');try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
-</div>
-<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px')}}catch(e){}</script>
-<!-- /RDI LIVESTREAM PROMO BANNER -->
 
   <img src="https://rdi.berkeley.edu/assets/images/events/SBC_Berkeley_Day_Banner_Standard.png" alt=""
     style="display:block; margin:auto; max-width:80%; height:auto; margin-top: 2%; margin-bottom: 2%;">

--- a/events/decentralizationaisummit24.html
+++ b/events/decentralizationaisummit24.html
@@ -36,6 +36,13 @@
     });
   </script>
 </head>
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<div id="rdi-promo-banner" style="position:relative;z-index:40;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none'}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
 
 <div class="constraint">
   <div id="header">
@@ -92,14 +99,6 @@
 </div>
 
 <body data-new-gr-c-s-check-loaded="14.1034.0" data-gr-ext-installed="">
-<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
-<style>header.sticky{top:var(--rdi-banner-h,42px)!important}</style>
-<div id="rdi-promo-banner" style="position:sticky;top:0;z-index:9999;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
-<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
-<button onclick="document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px');try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
-</div>
-<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px')}}catch(e){}</script>
-<!-- /RDI LIVESTREAM PROMO BANNER -->
 
   <img src="./sbc-assets/images/decentralizationaisummit24-v2.png" alt=""
     style="display:block; margin:auto; max-width:80%; height:auto; margin-top: 2%; margin-bottom: 2%;">

--- a/events/decentralizationaisummit25.html
+++ b/events/decentralizationaisummit25.html
@@ -36,6 +36,13 @@
     });
   </script> -->
 </head>
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<div id="rdi-promo-banner" style="position:relative;z-index:40;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none'}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
 
 <style>
   .styled-button {
@@ -176,14 +183,6 @@
 
 <script async src=”https://siteimproveanalytics.com/js/siteanalyze_6294756.js”></script>
 <body data-new-gr-c-s-check-loaded="14.1034.0" data-gr-ext-installed="">
-<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
-<style>header.sticky{top:var(--rdi-banner-h,42px)!important}</style>
-<div id="rdi-promo-banner" style="position:sticky;top:0;z-index:9999;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
-<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
-<button onclick="document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px');try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
-</div>
-<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px')}}catch(e){}</script>
-<!-- /RDI LIVESTREAM PROMO BANNER -->
 
   <img src="./sbc-assets/images/decentralizationaisummit25.jpg" alt=""
     style="display:block; margin:auto; max-width:80%; height:auto; margin-top: 2%; margin-bottom: 2%;">

--- a/events/zkpcareerfair.html
+++ b/events/zkpcareerfair.html
@@ -16,15 +16,14 @@
     <link rel="stylesheet" href="./info_files/css/style.css">
 
 </head>
-<body data-new-gr-c-s-check-loaded="14.1034.0" data-gr-ext-installed="">
 <!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
-<style>header.sticky{top:var(--rdi-banner-h,42px)!important}</style>
-<div id="rdi-promo-banner" style="position:sticky;top:0;z-index:9999;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<div id="rdi-promo-banner" style="position:relative;z-index:40;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
 <a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
-<button onclick="document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px');try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
 </div>
-<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px')}}catch(e){}</script>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none'}}catch(e){}</script>
 <!-- /RDI LIVESTREAM PROMO BANNER -->
+<body data-new-gr-c-s-check-loaded="14.1034.0" data-gr-ext-installed="">
 
     <div class="features-wrapper constraint">
 

--- a/xcelerator.html
+++ b/xcelerator.html
@@ -195,16 +195,15 @@
         }
     </style>
 </head>
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<div id="rdi-promo-banner" style="position:relative;z-index:40;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none'}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
 
 <body data-new-gr-c-s-check-loaded="14.1034.0" data-gr-ext-installed="">
-<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
-<style>header.sticky{top:var(--rdi-banner-h,42px)!important}</style>
-<div id="rdi-promo-banner" style="position:sticky;top:0;z-index:9999;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
-<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
-<button onclick="document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px');try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
-</div>
-<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none';document.documentElement.style.setProperty('--rdi-banner-h','0px')}}catch(e){}</script>
-<!-- /RDI LIVESTREAM PROMO BANNER -->
 
     <!-- Header Navigation -->
     <header class="sticky top-0 bg-white shadow z-50">


### PR DESCRIPTION
Follow-up to #72. The sticky banner interacted badly with sticky page headers, overlapping the nav buttons on some pages/scroll positions.

Fix: the banner is now static - it sits at the very top of the page and scrolls away with it (same behavior as the Nebius banner it was modeled on). Removes position:sticky and the header top-offset rule entirely, so the banner can no longer cover or displace any navigation. Same look, link, wording, and dismissal.

Verified with a full Jekyll build: compiles clean, one banner per page, zero sticky/offset remnants in any rendered page.