### PR TITLE
Add promo banner to research page and all remaining standalone pages

### DIFF
--- a/blog/peer-preservation/index.html
+++ b/blog/peer-preservation/index.html
@@ -814,6 +814,13 @@
         }
     </style>
 </head>
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<div id="rdi-promo-banner" style="position:relative;z-index:40;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none'}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
 <body>
     <div class="progress-bar" id="progressBar"></div>
 

--- a/course/berkeley-defi-f22.html
+++ b/course/berkeley-defi-f22.html
@@ -14,6 +14,13 @@
             }
         </style>
     </head>
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<div id="rdi-promo-banner" style="position:relative;z-index:40;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none'}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
     <body>
         <div id="content">
             <iframe aria-label="Decentralized Finance MOOC Content F22" width="100%" height="100%" frameborder="0" src="https://rdi.berkeley.edu/berkeley-defi/f22"></iframe>

--- a/course/berkeley-desys-s22.html
+++ b/course/berkeley-desys-s22.html
@@ -14,6 +14,13 @@
             }
         </style>
     </head>
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<div id="rdi-promo-banner" style="position:relative;z-index:40;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none'}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
     <body>
         <div id="content">
             <iframe aria-label="Syllabus" width="100%" height="100%" frameborder="0" src="https://rdi.berkeley.edu/berkeley-desys/s22"></iframe>

--- a/course/berkeley-genai-f23.html
+++ b/course/berkeley-genai-f23.html
@@ -14,6 +14,13 @@
             }
         </style>
     </head>
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<div id="rdi-promo-banner" style="position:relative;z-index:40;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none'}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
     <body>
         <div id="content">
             <iframe width="100%" height="100%" frameborder="0" src="https://rdi.berkeley.edu/responsible-genai/s22"></iframe>

--- a/course/entrepreneurship-in-web3.html
+++ b/course/entrepreneurship-in-web3.html
@@ -19,6 +19,13 @@
             }
         </style>
     </head>
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<div id="rdi-promo-banner" style="position:relative;z-index:40;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none'}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
     <body>
         <div id="content">
             <iframe aria-label="List of guest speakers" width="100%" height="100%" frameborder="0" src="https://rdi.berkeley.edu/entrepreneurship-in-web3/f22"></iframe>

--- a/course/zkp/s23.html
+++ b/course/zkp/s23.html
@@ -19,6 +19,13 @@
             }
         </style>
     </head>
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<div id="rdi-promo-banner" style="position:relative;z-index:40;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none'}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
     <body>
         <div id="content">
             <iframe aria-label="S23 ZKP Course Content" width="100%" height="100%" frameborder="0" src="https://rdi.berkeley.edu/zkp-course/s23"></iframe>

--- a/events/sbcberkeley.html
+++ b/events/sbcberkeley.html
@@ -4,5 +4,12 @@
 <head>
     <meta http-equiv="refresh" content="0; url='https://rdi.berkeley.edu/events/decentralizationaisummit'" />
 </head>
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<div id="rdi-promo-banner" style="position:relative;z-index:40;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none'}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
 
 </html>

--- a/research.html
+++ b/research.html
@@ -327,6 +327,13 @@
 
   </style>
 </head>
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<div id="rdi-promo-banner" style="position:relative;z-index:40;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none'}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
 <body class="text-gray-800">
 
   <!-- ====== NEW TAILWIND HEADER ====== -->

--- a/researchtest.html
+++ b/researchtest.html
@@ -64,6 +64,13 @@
     }
   </style>
 </head>
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<div id="rdi-promo-banner" style="position:relative;z-index:40;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none'}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
 <body class="text-gray-800">
 
 <!-- Header (matching homepage) -->

--- a/zkp-workshop-2022/agenda.html
+++ b/zkp-workshop-2022/agenda.html
@@ -38,6 +38,13 @@
 <!-- end custom head snippets -->
 
   </head>
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<div id="rdi-promo-banner" style="position:relative;z-index:40;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none'}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
   <body data-new-gr-c-s-check-loaded="14.1079.0" data-gr-ext-installed="">
     <a id="skip-to-content" href="https://zhiyong1997.github.io/cayman/agenda#content">Skip to the content.</a>
 

--- a/zkp-workshop-2022/index.html
+++ b/zkp-workshop-2022/index.html
@@ -38,6 +38,13 @@
 
 <script charset="utf-8" src="./index_files/button.d2f864f87f544dc0c11d7d712a191c1f.js.download"></script>
 </head>
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<div id="rdi-promo-banner" style="position:relative;z-index:40;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none'}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
 <body data-new-gr-c-s-check-loaded="14.1084.0" data-gr-ext-installed="">
 <!-- <div style="height: 50px; width: 100%; background-color: #003262; position:absolute;">
 <div class="constraint" style="color: white; font-size: 2rem;">

--- a/zkp-workshop-2022/registration.html
+++ b/zkp-workshop-2022/registration.html
@@ -38,6 +38,13 @@
 <!-- end custom head snippets -->
 
   </head>
+<!-- RDI LIVESTREAM PROMO BANNER: remove this whole block after the Summit -->
+<div id="rdi-promo-banner" style="position:relative;z-index:40;background:#FDB515;text-align:center;padding:10px 48px;font-family:'Poppins',Arial,sans-serif;font-size:15px;font-weight:600;">
+<a href="https://luma.com/livestream-agenticaisummit" style="color:#003262;text-decoration:none;">Watch Live: Agentic AI Summit 2026 — RSVP Now</a>
+<button onclick="document.getElementById('rdi-promo-banner').style.display='none';try{localStorage.setItem('rdiPromo2026','dismissed')}catch(e){}" aria-label="Dismiss banner" style="position:absolute;right:14px;top:50%;transform:translateY(-50%);background:none;border:none;font-size:19px;line-height:1;color:#003262;cursor:pointer;padding:2px 6px;">×</button>
+</div>
+<script>try{if(localStorage.getItem('rdiPromo2026')==='dismissed'){document.getElementById('rdi-promo-banner').style.display='none'}}catch(e){}</script>
+<!-- /RDI LIVESTREAM PROMO BANNER -->
   <body data-new-gr-c-s-check-loaded="14.1079.0" data-gr-ext-installed="">
     <a id="skip-to-content" href="https://zhiyong1997.github.io/cayman/registration#content">Skip to the content.</a>
 


### PR DESCRIPTION
Completes site-wide banner coverage from #72/#73. Adds the same static banner block (above the header, after </head>) to the remaining standalone pages that don't use Jekyll layouts:

research.html (the /research/ page), researchtest.html, events/sbcberkeley.html, the zkp-workshop-2022 pages, blog/peer-preservation, and the five course pages (zkp s23, defi f22, genai f23, desys s22, entrepreneurship-in-web3).

cesc.html intentionally skipped - it's a meta-refresh redirect to cesc.io, nothing renders there.

Verified with a full Jekyll build: every rendered page in the site now carries exactly one banner, no doubles.