### PR TITLE
Update Temporal workshop title and speaker

### DIFF
--- a/events/agentic-ai-summit-2026.html
+++ b/events/agentic-ai-summit-2026.html
@@ -1643,7 +1643,13 @@
           <div class="event workshop">
               <div class="event-time">2:00 PM</div>
               <div class="event-content">
-                  <div class="event-title">Workshop by Temporal</div>
+                  <div class="event-title">Workshop: Build AI Agents That Survive Failure by Temporal</div>
+                  <div class="speaker">
+                      <div class="speaker-header">
+                          <div class="speaker-name">Nikolay Advolodkin</div>
+                          <div class="speaker-title">Senior Staff Developer Advocate, Temporal</div>
+                      </div>
+                  </div>
               </div>
           </div>
           <div class="session-block-wrap">


### PR DESCRIPTION
Replaces the 'Workshop by Temporal' placeholder on Compass Saturday 2:00 PM with the confirmed title and lead speaker provided by Temporal: 'Build AI Agents That Survive Failure', Nikolay Advolodkin, Senior Staff Developer Advocate. Matches the existing workshop markup pattern. Div balance unchanged at -1.