### PR TITLE
Fix agenda times wrapping onto two lines on mobile

### DIFF
--- a/events/agentic-ai-summit-2026.html
+++ b/events/agentic-ai-summit-2026.html
@@ -285,7 +285,7 @@
       .workshop .event-time::after { background: #c026a8; }
       .keynote .event-time::after { background: #34a853; }
       .moderator { margin-top: 8px; color: var(--text-light); font-size: 14px; }
-      @media (max-width: 720px) { .timeline::before { left: 88px; } .event-time { flex-basis: 74px; padding-right: 24px; } }
+      @media (max-width: 720px) { .timeline::before { left: 106px; } .event-time { flex-basis: 92px; padding-right: 24px; } }
     </style>
     <script>
       function showAgendaTab(index) {


### PR DESCRIPTION
On viewports at or below 720px the time column was 74px wide with 24px padding, leaving only 50px of usable width. Times are up to 8 characters (for example 10:25 AM, 2:00 PM), so they wrapped onto two lines. Widened the column to 92px (68px usable) and shifted the timeline rail from 88px to 106px to preserve the original gap between the rail and the time column. CSS only, no markup changes. Div balance unchanged at -1.