### PR TITLE
Add Temporal Frontier talk to Session 2 Frameworks and Dev Platforms

### DIFF
--- a/events/agentic-ai-summit-2026.html
+++ b/events/agentic-ai-summit-2026.html
@@ -1606,6 +1606,13 @@
                   </div>
                   <div class="speaker">
                       <div class="speaker-header">
+                          <div class="speaker-name">Melanie Warrick</div>
+                          <div class="speaker-title">Senior Staff Developer Advocate, Temporal</div>
+                      </div>
+                      <div class="event-title-2">What an Agent Needs to Remember</div>
+                  </div>
+                  <div class="speaker">
+                      <div class="speaker-header">
                           <div class="speaker-name">Shiva Kasiviswanthan</div>
                           <div class="speaker-title">Principal Applied Scientist, Amazon Web Services</div>
                       </div>


### PR DESCRIPTION
Adds Melanie Warrick (Senior Staff Developer Advocate, Temporal) and her talk 'What an Agent Needs to Remember' to Session 2, placed directly under Ramesh Raskar per Linda. Matches the existing speaker markup pattern. Div balance unchanged at -1.