### PR TITLE
Move Melanie Warrick to the end of the Session 2 speaker list

### DIFF
--- a/events/agentic-ai-summit-2026.html
+++ b/events/agentic-ai-summit-2026.html
@@ -1606,13 +1606,6 @@
                   </div>
                   <div class="speaker">
                       <div class="speaker-header">
-                          <div class="speaker-name">Melanie Warrick</div>
-                          <div class="speaker-title">Senior Staff Developer Advocate, Temporal</div>
-                      </div>
-                      <div class="event-title-2">What an Agent Needs to Remember</div>
-                  </div>
-                  <div class="speaker">
-                      <div class="speaker-header">
                           <div class="speaker-name">Shiva Kasiviswanthan</div>
                           <div class="speaker-title">Principal Applied Scientist, Amazon Web Services</div>
                       </div>
@@ -1643,6 +1636,13 @@
                           <div class="speaker-name">Nilou Salehi</div>
                           <div class="speaker-title">Associate professor, UC, Berkeley</div>
                       </div>
+                  </div>
+                  <div class="speaker">
+                      <div class="speaker-header">
+                          <div class="speaker-name">Melanie Warrick</div>
+                          <div class="speaker-title">Senior Staff Developer Advocate, Temporal</div>
+                      </div>
+                      <div class="event-title-2">What an Agent Needs to Remember</div>
                   </div>
               </div>
           </div>


### PR DESCRIPTION
Repositions the Temporal Frontier talk from directly under Ramesh Raskar to the last entry in Session 2, after Nilou Salehi. Div balance unchanged at -1.